### PR TITLE
Slash commands update

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,15 @@ $ docker-compose up --build -d
 
 ## Usage
 
-The bot has 1 slash/application commands (type '/' to view them). You need to use the sync prefix command first for application commands to show. The prefix set for this bot is its own @mention. Example: `@andaluhbot sync`.
+The bot has 1 slash/application command (type '/' to view them). You need to use the sync prefix command first for application commands to show. The prefix set for this bot is its own @mention. Example: `@andaluhbot sync`.
 
 * `/andaluh`: Get Andalûh EPA standard transliteration (using 'ç')
 
 The command has two parameters:
-
 * `text`: Text to transliterate
-* `[Optional] variant`: Choose one of the three variants of transliteration instead of 'ç' (zezeo, seseo or heheo)
+* `variant [Optional]`: Choose one of the three variants of transliteration instead of 'ç' (zezeo, seseo or heheo)
+
+If the bot has the `MANAGE_WEBHOOKS` permission, it will show the transliteration using the avatar image and display name of the user who called the command, as if it was sent from their account. This allows for a more natural conversation.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ $ docker-compose up --build -d
 
 ## Usage
 
-The bot has 4 slash/application commands (type '/' to view them). You need to use the sync prefix command first for application commands to show. The prefix set for this bot is its own @mention. Example: `@andaluhbot sync`.
+The bot has 1 slash/application commands (type '/' to view them). You need to use the sync prefix command first for application commands to show. The prefix set for this bot is its own @mention. Example: `@andaluhbot sync`.
 
-* `/an`: Get Andalûh EPA standard transliteration (using 'ç')
-* `/anz`: Andalûh EPA Zezeo transliteration
-* `/ans`: Andalûh EPA Seseo transliteration
-* `/anh`: Andalûh EPA Heheo transliteration
+* `/andaluh`: Get Andalûh EPA standard transliteration (using 'ç')
+
+The command has two parameters:
+
+* `text`: Text to transliterate
+* `[Optional] variant`: Choose one of the three variants of transliteration instead of 'ç' (zezeo, seseo or heheo)
 
 ## Support
 

--- a/app/andaluhbot.py
+++ b/app/andaluhbot.py
@@ -8,7 +8,7 @@
 import os
 
 import requests
-from discord import Embed, Intents, Interaction, app_commands
+from discord import Embed, Intents, Interaction, TextChannel, app_commands
 from discord.errors import Forbidden
 from discord.ext import commands
 from dotenv import load_dotenv
@@ -67,18 +67,20 @@ async def help(ctx: commands.Context):
 async def andaluh(
     interaction: Interaction, text: str, variant: app_commands.Choice[str] = None
 ):
-    await interaction.response.defer(
-        ephemeral=interaction.app_permissions.manage_webhooks
+    use_webook = (
+        isinstance(interaction.channel, TextChannel)
+        and interaction.app_permissions.manage_webhooks
     )
+    await interaction.response.defer(ephemeral=use_webook)
 
     params = {"spanish": text, "escapeLinks": True}
     if variant:
         params["vaf"] = variant.value
     result = requests.get(API_ANDALUH, params=params).json()
 
-    try:
+    if use_webook:
         await send_webhook_message(interaction, result["andaluh"])
-    except Forbidden:
+    else:
         await interaction.followup.send(result["andaluh"])
 
 

--- a/app/andaluhbot.py
+++ b/app/andaluhbot.py
@@ -9,7 +9,6 @@ import os
 
 import requests
 from discord import Embed, Intents, Interaction, TextChannel, app_commands
-from discord.errors import Forbidden
 from discord.ext import commands
 from dotenv import load_dotenv
 

--- a/app/andaluhbot.py
+++ b/app/andaluhbot.py
@@ -8,7 +8,7 @@
 import os
 
 import requests
-from discord import Intents, Interaction, app_commands
+from discord import Embed, Intents, Interaction, app_commands
 from discord.ext import commands
 from dotenv import load_dotenv
 
@@ -21,12 +21,9 @@ bot = commands.Bot(
 )
 
 HELP = """
-🇳🇬 Guenâ! Çoy un bot trâccrîttôh Andalûh EPA. Dîppongo de lô çigientê comandô. Pruébalô:
+Guenâ! Çoy un bot trâccrîttôh Andalûh EPA. Dîppongo de lô çigientê comandô. Pruébalô:
 
-/an   Trâccribe Câtteyano - Andalûh (EPA) uçando grafía integraora 'ç'
-/anz  Iguâh pero zezeando
-/ans  Iguâh pero seseando
-/anh  Iguâh pero heheando
+``/andaluh`` Trâccribe Câtteyano -> Andalûh (EPA) uçando grafía integraora 'ç' o una de çûh bariantê de zezeo, seseo o heheo.
 
 Çi quierê çabêh mâh çobre Andalûh y EPA:
 
@@ -34,6 +31,7 @@ HELP = """
 👉 Trâccrîttôh online https://andaluh.es/transcriptor
 👉 Teclao Andalûh EPA https://andaluh.es/teclado-andaluz
 """
+EMBED_COLOR = 0x5DBB41
 
 
 @bot.event
@@ -42,6 +40,7 @@ async def on_ready():
 
 
 @bot.command(help="Sync bot tree")
+@commands.is_owner()
 async def sync(ctx: commands.Context):
     await bot.tree.sync()
     await ctx.send("Synced application commands")
@@ -49,54 +48,43 @@ async def sync(ctx: commands.Context):
 
 @bot.command(help="Bot help")
 async def help(ctx: commands.Context):
-    await ctx.send(HELP)
+    await ctx.send(embed=Embed(description=HELP, color=EMBED_COLOR))
 
 
-# Andaluh slash commands
-@bot.tree.command(description="Type in spanish to get Andalûh EPA transliteration.")
-@app_commands.describe(text="Text to transliterate")
-async def an(interaction: Interaction, text: str):
-    await interaction.response.defer()
-    result = requests.get(
-        API_ANDALUH, params=dict(spanish=text, escapeLinks=True)
-    ).json()
-    await interaction.followup.send(result["andaluh"])
-
-
-@bot.tree.command(
-    description="Type in spanish to get Andalûh EPA Zezeo transliteration."
+# Andaluh slash command
+@bot.tree.command(description="Type in Spanish to get Andalûh EPA transliteration")
+@app_commands.describe(
+    text="Text to transliterate", variant="Transliterate using one of the variants"
 )
-@app_commands.describe(text="Text to transliterate")
-async def anz(interaction: Interaction, text: str):
-    await interaction.response.defer()
-    result = requests.get(
-        API_ANDALUH, params=dict(spanish=text, escapeLinks=True, vaf="z")
-    ).json()
-    await interaction.followup.send(result["andaluh"])
-
-
-@bot.tree.command(
-    description="Type in spanish to get Andalûh EPA Seseo transliteration."
+@app_commands.choices(
+    variant=[
+        app_commands.Choice(name="Zezeo", value="z"),
+        app_commands.Choice(name="Seseo", value="s"),
+        app_commands.Choice(name="Heheo", value="h"),
+    ]
 )
-@app_commands.describe(text="Text to transliterate")
-async def ans(interaction: Interaction, text: str):
-    await interaction.response.defer()
-    result = requests.get(
-        API_ANDALUH, params=dict(spanish=text, escapeLinks=True, vaf="s")
-    ).json()
-    await interaction.followup.send(result["andaluh"])
+async def andaluh(
+    interaction: Interaction, text: str, variant: app_commands.Choice[str] = None
+):
+    await interaction.response.defer(ephemeral=True)
+
+    params = {"spanish": text, "escapeLinks": True}
+    if variant:
+        params["vaf"] = variant.value
+    result = requests.get(API_ANDALUH, params=params).json()
+
+    await send_webhook_message(interaction, result["andaluh"])
+    await interaction.followup.send("Tradûççión finiquitá!")
 
 
-@bot.tree.command(
-    description="Type in spanish to get Andalûh EPA Heheo transliteration."
-)
-@app_commands.describe(text="Text to transliterate")
-async def anh(interaction: Interaction, text: str):
-    await interaction.response.defer()
-    result = requests.get(
-        API_ANDALUH, params=dict(spanish=text, escapeLinks=True, vaf="h")
-    ).json()
-    await interaction.followup.send(result["andaluh"])
+async def send_webhook_message(interaction: Interaction, text):
+    webhook = await interaction.channel.create_webhook(name=bot.user.name)
+    await webhook.send(
+        text,
+        username=interaction.user.display_name,
+        avatar_url=interaction.user.display_avatar.url,
+    )
+    await webhook.delete()
 
 
 def main():

--- a/app/andaluhbot.py
+++ b/app/andaluhbot.py
@@ -8,7 +8,7 @@
 import os
 
 import requests
-from discord import Intents, Interaction, app_commands
+from discord import Embed, Intents, Interaction, app_commands
 from discord.ext import commands
 from dotenv import load_dotenv
 
@@ -21,12 +21,9 @@ bot = commands.Bot(
 )
 
 HELP = """
-🇳🇬 Guenâ! Çoy un bot trâccrîttôh Andalûh EPA. Dîppongo de lô çigientê comandô. Pruébalô:
+Guenâ! Çoy un bot trâccrîttôh Andalûh EPA. Dîppongo de lô çigientê comandô. Pruébalô:
 
-/an   Trâccribe Câtteyano - Andalûh (EPA) uçando grafía integraora 'ç'
-/anz  Iguâh pero zezeando
-/ans  Iguâh pero seseando
-/anh  Iguâh pero heheando
+``/andaluh`` Trâccribe Câtteyano -> Andalûh (EPA) uçando grafía integraora 'ç' o una de çûh bariantê de zezeo, seseo o heheo.
 
 Çi quierê çabêh mâh çobre Andalûh y EPA:
 
@@ -34,6 +31,7 @@ HELP = """
 👉 Trâccrîttôh online https://andaluh.es/transcriptor
 👉 Teclao Andalûh EPA https://andaluh.es/teclado-andaluz
 """
+EMBED_COLOR = 0x5DBB41
 
 
 @bot.event
@@ -42,6 +40,7 @@ async def on_ready():
 
 
 @bot.command(help="Sync bot tree")
+@commands.is_owner()
 async def sync(ctx: commands.Context):
     await bot.tree.sync()
     await ctx.send("Synced application commands")
@@ -49,54 +48,43 @@ async def sync(ctx: commands.Context):
 
 @bot.command(help="Bot help")
 async def help(ctx: commands.Context):
-    await ctx.send(HELP)
+    await ctx.send(embed=Embed(description=HELP, color=EMBED_COLOR))
 
 
-# Andaluh slash commands
-@bot.tree.command(description="Type in spanish to get Andalûh EPA transliteration.")
-@app_commands.describe(text="Text to transliterate")
-async def an(interaction: Interaction, text: str):
-    await interaction.response.defer()
-    result = requests.get(
-        API_ANDALUH, params=dict(spanish=text, escapeLinks=True)
-    ).json()
-    await interaction.followup.send(result["andaluh"])
-
-
-@bot.tree.command(
-    description="Type in spanish to get Andalûh EPA Zezeo transliteration."
+# Andaluh slash command
+@bot.tree.command(description="Type in Spanish to get Andalûh EPA transliteration")
+@app_commands.describe(
+    text="Text to transliterate", variant="Transliterate using one of the variants"
 )
-@app_commands.describe(text="Text to transliterate")
-async def anz(interaction: Interaction, text: str):
-    await interaction.response.defer()
-    result = requests.get(
-        API_ANDALUH, params=dict(spanish=text, escapeLinks=True, vaf="z")
-    ).json()
-    await interaction.followup.send(result["andaluh"])
-
-
-@bot.tree.command(
-    description="Type in spanish to get Andalûh EPA Seseo transliteration."
+@app_commands.choices(
+    variant=[
+        app_commands.Choice(name="Zezeo", value="z"),
+        app_commands.Choice(name="Seseo", value="s"),
+        app_commands.Choice(name="Heheo", value="h"),
+    ]
 )
-@app_commands.describe(text="Text to transliterate")
-async def ans(interaction: Interaction, text: str):
+async def andaluh(
+    interaction: Interaction, text: str, variant: app_commands.Choice[str] = None
+):
     await interaction.response.defer()
-    result = requests.get(
-        API_ANDALUH, params=dict(spanish=text, escapeLinks=True, vaf="s")
-    ).json()
-    await interaction.followup.send(result["andaluh"])
+
+    params = {"spanish": text, "escapeLinks": True}
+    if variant:
+        params["vaf"] = variant
+    result = requests.get(API_ANDALUH, params=params).json()
+
+    await send_webhook_message(interaction, result["andaluh"])
+    await interaction.followup.send("Tradûççión finiquitá!")
 
 
-@bot.tree.command(
-    description="Type in spanish to get Andalûh EPA Heheo transliteration."
-)
-@app_commands.describe(text="Text to transliterate")
-async def anh(interaction: Interaction, text: str):
-    await interaction.response.defer()
-    result = requests.get(
-        API_ANDALUH, params=dict(spanish=text, escapeLinks=True, vaf="h")
-    ).json()
-    await interaction.followup.send(result["andaluh"])
+async def send_webhook_message(interaction: Interaction, text):
+    webhook = await interaction.channel.create_webhook(name=bot.user.name)
+    await webhook.send(
+        text,
+        username=interaction.user.display_name,
+        avatar_url=interaction.user.display_avatar.url,
+    )
+    await webhook.delete()
 
 
 def main():


### PR DESCRIPTION
## Cambiâh er nombre der comando /an a /andaluh
Êtte comando çe yamaba açí porque antê er bot no tenía Slash commands, çino que abía que êccribîh lô comandô en meçahê y era mâh corto an pero aora con lô Slash commands çe autocompleta al êccribîh y çe puede çelêççionâh de la lîtta.
`/andaluh` êh mâh intuitibo pa çabêh lo que açe er comando (traduçîh ar Andalûh).

![image](https://github.com/user-attachments/assets/d4362730-bbd6-4f00-b2f9-cc59714c7a38)

## Huntâh lô comandô /anz /ans y /anh en er mîmmo comando /andaluh
En lugâh de tenêh trêh comandô pa cá una de lâ bariantê, e probao a huntâl-lô en er mîmmo comando con un parámetro ôççionâh pa çelêççionâh una bariante de la lîtta.

![image](https://github.com/user-attachments/assets/613fe29d-02bf-4fd1-abea-d28a17d5fb52)

## Mandâh lô mençahê como el uçuario
En lugâh de uçâh er comando y reçibîh la tradûççión dêdde la cuenta der bot, e probao a utiliçâh lô webhooks de Discord pa que er bot embíe un mençahe imitando al uçuario que uça er comando (con er mîmmo nombre de uçuario y foto de perfîh). Açí çe puede tenêh una comberçaçión de manera mâh naturâh.

La manera en la que funçiona êh que er bot crea un webhook en er canâh de manera temporâh y lo elimina trâ embiâh er mençahe con la tradûççión.

![image](https://github.com/user-attachments/assets/5e246733-a8e6-43c3-8916-4dbd5207dd79)
